### PR TITLE
new footer with form

### DIFF
--- a/src/layouts/layout-default.vue
+++ b/src/layouts/layout-default.vue
@@ -2,6 +2,7 @@
 import { onMounted, ref } from 'vue';
 
 import { RouterView } from 'vue-router';
+import { useQuasar } from 'quasar';
 
 import NavMenu from '@/components/NavMenu.vue';
 
@@ -9,6 +10,26 @@ const leftDrawerOpen = ref(true);
 
 const toggleLeftDrawer = () => {
 	leftDrawerOpen.value = !leftDrawerOpen.value;
+};
+
+const $q = useQuasar();
+
+const subscribeEmail = ref('');
+
+const emailRules = [
+	(val: string) => (val && val.length > 0) || 'Please type your email',
+	(val: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val) || 'Please type a valid email',
+];
+
+const onSubscribeSubmit = () => {
+	$q.notify({
+		message: 'Subscribed successfully',
+		type: 'positive',
+		position: 'top',
+		timeout: 1000,
+	});
+
+	subscribeEmail.value = '';
 };
 </script>
 
@@ -36,14 +57,30 @@ const toggleLeftDrawer = () => {
 			<RouterView />
 		</QPageContainer>
 
-		<!-- <QFooter elevated class="bg-grey-8 text-white">
+		<QFooter elevated class="bg-grey-8 text-white">
 			<QToolbar>
 				<QToolbarTitle>
 					<QAvatar>
 						<img src="https://cdn.quasar.dev/logo-v2/svg/logo-mono-white.svg" />
 					</QAvatar>
 				</QToolbarTitle>
+
+				<QForm class="row items-start q-gutter-sm" @submit="onSubscribeSubmit">
+					<QInput
+						dark
+						dense
+						filled
+						type="email"
+						v-model="subscribeEmail"
+						label="Subscribe to our newsletter"
+						style="min-width: 260px"
+						lazy-rules
+						:rules="emailRules"
+					/>
+
+					<QBtn label="Subscribe" type="submit" color="primary" />
+				</QForm>
 			</QToolbar>
-		</QFooter> -->
+		</QFooter>
 	</QLayout>
 </template>


### PR DESCRIPTION
## Цель

Add a footer with an email subscription form to the admin panel's default layout, so it appears at the bottom of every page and lets a user submit an email address with client-side validation and confirmation feedback.

## Критерии приёмки

- [ ] AC-1: A footer is visible at the bottom of every page rendered inside the default layout
- [ ] AC-2: The footer contains an email input field and a subscribe/submit button
- [ ] AC-3: Submitting the form with an empty email field is rejected with a visible validation error and no success confirmation is shown
- [ ] AC-4: Submitting the form with a malformed email (e.g. 'notanemail') is rejected with a visible validation error
- [ ] AC-5: Submitting the form with a well-formed email succeeds: a success confirmation is shown and the input is cleared

---
Задача `18e861a7` · ветка `sdai/new-footer-with-form-18e861a7` · PR открыт ролью Developer (self-developer-ai)